### PR TITLE
Change to saving the admin promote password in redis

### DIFF
--- a/Wave/Components/Pages/Admin.razor
+++ b/Wave/Components/Pages/Admin.razor
@@ -5,6 +5,8 @@
 @using Wave.Components.Account.Shared
 @using Wave.Data
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.Extensions.Caching.Distributed;
+@using System.Text;
 
 @attribute [Authorize]
 @inject IdentityUserAccessor UserAccessor
@@ -13,6 +15,7 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject IdentityRedirectManager RedirectManager
 @inject IStringLocalizer<Admin> Localizer
+@inject IDistributedCache WaveDistributedCache
 
 <PageTitle>@(TitlePrefix + Localizer["Title"])</PageTitle>
 
@@ -52,8 +55,8 @@
     protected override async Task OnInitializedAsync() {
         User = await UserAccessor.GetRequiredUserAsync(HttpContext);
 
-        string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "admin.txt");
-        if (File.Exists(path)) Password = await File.ReadAllTextAsync(path);
+        Password = await WaveDistributedCache.GetStringAsync("admin_promote_key")
+                   ?? "";
     }
 
     private async Task Promote() {
@@ -76,7 +79,7 @@
             }
         }
         await UserManager.AddToRoleAsync(User, "Admin");
-        File.Delete(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "admin.txt"));
+        await WaveDistributedCache.RemoveAsync("admin_promote_key");
         await SignInManager.RefreshSignInAsync(User);
         Message = "You have been promoted, this tool is now disabled.";
     }


### PR DESCRIPTION
For initial creation of an admin account, when no account with the `admin` role is found on startup, wave creates a password and displays it in the log.

Previously, this value was saved temporarely in a file, /app/admin.txt. On some deployments e.g. kubernetes this caused crashes, because this location isnt writable by the "app" user wave is running as.

Now, wave saves this value in redis instead.